### PR TITLE
fix: Bonding products - `active` when wallet is connected

### DIFF
--- a/components/Home/BondingProducts.jsx
+++ b/components/Home/BondingProducts.jsx
@@ -23,7 +23,11 @@ export const BondingProducts = () => {
 
   useEffect(() => {
     if (account) {
+      // if user is connected, show active products
       setProductType('active');
+    } else {
+      // if user disconnected, switch to all products
+      setProductType('allProduct');
     }
   }, [account]);
 

--- a/components/Home/BondingProducts.jsx
+++ b/components/Home/BondingProducts.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Typography, Radio } from 'antd/lib';
 import { useHelpers } from 'common-util/hooks/useHelpers';
@@ -20,6 +20,12 @@ export const BondingProducts = () => {
   const [bondingProgramType, setProductType] = useState(
     account ? 'active' : 'allProduct',
   );
+
+  useEffect(() => {
+    if (account) {
+      setProductType('active');
+    }
+  }, [account]);
 
   const onChange = (e) => {
     setProductType(e.target.value);


### PR DESCRIPTION
* Radio button will be switched to `Active` if the user has connected else `All Products`
* On logout it will shifted back to `All Products`

https://github.com/valory-xyz/autonolas-tokenomics-frontend/assets/22061815/75aaf31e-ddb1-4f25-8297-308fde6e3566

