### PR TITLE
Feat hide empty products

### DIFF
--- a/components/GlobalStyles/index.jsx
+++ b/components/GlobalStyles/index.jsx
@@ -30,11 +30,24 @@ const GlobalStyle = createGlobalStyle`
   .m-0 {
     margin: 0 !important;
   }
+  .my-0 {
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+  }
+  .mb-0 {
+    margin-bottom: 0 !important;
+  }
   .mb-8 {
     margin-bottom: 0.5rem;
   }
   .mb-16 {
     margin-bottom: 1rem;
+  }
+  .mr-4 {
+    margin-right: 4px;
+  }
+  .mr-8 {
+    margin-right: 8px;
   }
   .mr-12 {
     margin-right: 12px;

--- a/components/Home/Bonding/BondingList.jsx
+++ b/components/Home/Bonding/BondingList.jsx
@@ -240,7 +240,7 @@ export const BondingList = ({ bondingProgramType, hideEmptyProducts }) => {
 
   const filterList = (list) => {
     if (hideEmptyProducts) {
-      return list.filter((x) => x.supplyLeft > 0);
+      return list.filter((x) => x.supplyLeft > 0.001);
     }
 
     return list;
@@ -296,5 +296,5 @@ BondingList.propTypes = {
 
 BondingList.defaultProps = {
   bondingProgramType: 'active',
-  hideEmptyProducts: true,
+  hideEmptyProducts: 'active',
 };

--- a/components/Home/Bonding/BondingList.jsx
+++ b/components/Home/Bonding/BondingList.jsx
@@ -238,19 +238,12 @@ export const BondingList = ({ bondingProgramType, hideEmptyProducts }) => {
     return b.projectedChange - a.projectedChange;
   });
 
-  const filterList = (list) => {
-    if (hideEmptyProducts) {
-      return list.filter((x) => x.supplyLeft > 0.001);
-    }
-
-    return list;
-  };
-
   const getProductsDataSource = () => {
     const list = showNoSupply ? allProducts : filteredProducts;
 
     const sortedList = sortList(list);
-    const processedList = filterList(sortedList);
+    const processedList = hideEmptyProducts
+      ? sortedList.filter((x) => x.supplyLeft > 0.001) : sortedList;
 
     return processedList;
   };

--- a/components/Home/Bonding/BondingList.jsx
+++ b/components/Home/Bonding/BondingList.jsx
@@ -182,7 +182,7 @@ const getColumns = (
   return columns;
 };
 
-export const BondingList = ({ bondingProgramType }) => {
+export const BondingList = ({ bondingProgramType, hideEmptyProducts }) => {
   const { account, chainId } = useHelpers();
   const [isLoading, setIsLoading] = useState(false);
   const [allProducts, setAllProducts] = useState([]); // all products
@@ -232,14 +232,27 @@ export const BondingList = ({ bondingProgramType }) => {
     setProductDetails(null);
   };
 
+  const sortList = (list) => list.sort((a, b) => {
+    if (isNaN(a.projectedChange)) return 1;
+    if (isNaN(b.projectedChange)) return -1;
+    return b.projectedChange - a.projectedChange;
+  });
+
+  const filterList = (list) => {
+    if (hideEmptyProducts) {
+      return list.filter((x) => x.supplyLeft > 0);
+    }
+
+    return list;
+  };
+
   const getProductsDataSource = () => {
     const list = showNoSupply ? allProducts : filteredProducts;
-    const sortedList = list.sort((a, b) => {
-      if (isNaN(a.projectedChange)) return 1;
-      if (isNaN(b.projectedChange)) return -1;
-      return b.projectedChange - a.projectedChange;
-    });
-    return sortedList;
+
+    const sortedList = sortList(list);
+    const processedList = filterList(sortedList);
+
+    return processedList;
   };
 
   return (
@@ -278,8 +291,10 @@ export const BondingList = ({ bondingProgramType }) => {
 
 BondingList.propTypes = {
   bondingProgramType: PropTypes.string,
+  hideEmptyProducts: PropTypes.bool,
 };
 
 BondingList.defaultProps = {
   bondingProgramType: 'active',
+  hideEmptyProducts: true,
 };

--- a/components/Home/BondingProducts.jsx
+++ b/components/Home/BondingProducts.jsx
@@ -1,17 +1,33 @@
 import { useState } from 'react';
 import styled from 'styled-components';
-import { Typography, Radio } from 'antd';
+import {
+  Typography, Radio, Switch, Divider,
+} from 'antd';
 
 import { BONDING_PRODUCTS } from 'util/constants';
+import { useScreen } from '@autonolas/frontend-library';
 import { BondingList } from './Bonding/BondingList';
 
 const { Title } = Typography;
 
-const ProductContainer = styled.div`
-  .ant-typography {
-    display: flex;
-    align-items: center;
-  }
+const PageHeader = styled.div`
+  align-items: center;
+  margin-bottom: 12px;
+  display: ${(props) => (props.isMobile ? 'block' : 'flex')};
+`;
+
+const StyledDivider = styled(Divider)`
+  margin: ${(props) => (props.isMobile ? '12px 0 ' : '0 12px')};
+`;
+
+const ResponsiveDivider = () => {
+  const { isMobile } = useScreen();
+
+  return <StyledDivider isMobile={isMobile} type={isMobile ? 'horizontal' : 'vertical'} />;
+};
+
+const StyledRadioGroup = styled(Radio.Group)`
+  
 `;
 
 export const BondingProducts = () => {
@@ -19,23 +35,44 @@ export const BondingProducts = () => {
   const [bondingProgramType, setProductType] = useState(
     BONDING_PRODUCTS.ACTIVE,
   );
+  const [hideEmptyProducts, setHideEmptyProducts] = useState(true);
+  const { isMobile } = useScreen();
 
   const onChange = (e) => {
     setProductType(e.target.value);
   };
 
+  const onToggle = (checked) => {
+    setHideEmptyProducts(checked);
+  };
+
   return (
-    <ProductContainer>
-      <Title level={2} className="choose-type-group">
-        Bonding Products
-        <Radio.Group onChange={onChange} value={bondingProgramType}>
+    <>
+      <PageHeader isMobile={isMobile}>
+        <Title level={4} className="mb-0 mt-0">
+          Bonding Products
+        </Title>
+        <ResponsiveDivider />
+        <StyledRadioGroup onChange={onChange} value={bondingProgramType}>
           <Radio value={BONDING_PRODUCTS.ALL}>All</Radio>
           <Radio value={BONDING_PRODUCTS.ACTIVE}>Active</Radio>
           <Radio value={BONDING_PRODUCTS.INACTIVE}>Inactive</Radio>
-        </Radio.Group>
-      </Title>
+        </StyledRadioGroup>
+        <ResponsiveDivider />
+        <div>
+          <Switch
+            checked={hideEmptyProducts}
+            onChange={onToggle}
+            className="mr-8"
+          />
+          Hide empty products
+        </div>
+      </PageHeader>
 
-      <BondingList bondingProgramType={bondingProgramType} />
-    </ProductContainer>
+      <BondingList
+        bondingProgramType={bondingProgramType}
+        hideEmptyProducts={hideEmptyProducts}
+      />
+    </>
   );
 };

--- a/components/Home/BondingProducts.jsx
+++ b/components/Home/BondingProducts.jsx
@@ -20,15 +20,16 @@ const StyledDivider = styled(Divider)`
   margin: ${(props) => (props.isMobile ? '12px 0 ' : '0 12px')};
 `;
 
+const SwitchContainer = styled.div`
+  align-items: center;
+  display: flex;
+`;
+
 const ResponsiveDivider = () => {
   const { isMobile } = useScreen();
 
   return <StyledDivider isMobile={isMobile} type={isMobile ? 'horizontal' : 'vertical'} />;
 };
-
-const StyledRadioGroup = styled(Radio.Group)`
-  
-`;
 
 export const BondingProducts = () => {
   // if user not connected, show all products
@@ -53,20 +54,20 @@ export const BondingProducts = () => {
           Bonding Products
         </Title>
         <ResponsiveDivider />
-        <StyledRadioGroup onChange={onChange} value={bondingProgramType}>
+        <Radio.Group onChange={onChange} value={bondingProgramType}>
           <Radio value={BONDING_PRODUCTS.ALL}>All</Radio>
           <Radio value={BONDING_PRODUCTS.ACTIVE}>Active</Radio>
           <Radio value={BONDING_PRODUCTS.INACTIVE}>Inactive</Radio>
-        </StyledRadioGroup>
+        </Radio.Group>
         <ResponsiveDivider />
-        <div>
+        <SwitchContainer>
           <Switch
             checked={hideEmptyProducts}
             onChange={onToggle}
             className="mr-8"
           />
           Hide empty products
-        </div>
+        </SwitchContainer>
       </PageHeader>
 
       <BondingList

--- a/components/Layout/index.jsx
+++ b/components/Layout/index.jsx
@@ -4,10 +4,10 @@ import dynamic from 'next/dynamic';
 import PropTypes from 'prop-types';
 import { Layout, Menu } from 'antd';
 import { ExportOutlined } from '@ant-design/icons';
+import styled from 'styled-components';
+import { COLOR } from '@autonolas/frontend-library';
 
 import { useHelpers } from 'common-util/hooks/useHelpers';
-import { COLOR } from '@autonolas/frontend-library';
-import styled from 'styled-components';
 import Login from '../Login';
 import Footer from './Footer';
 import { CustomLayout, Logo, DocsLink } from './styles';

--- a/components/Layout/index.jsx
+++ b/components/Layout/index.jsx
@@ -6,6 +6,8 @@ import { Layout, Menu } from 'antd';
 import { ExportOutlined } from '@ant-design/icons';
 
 import { useHelpers } from 'common-util/hooks/useHelpers';
+import { COLOR } from '@autonolas/frontend-library';
+import styled from 'styled-components';
 import Login from '../Login';
 import Footer from './Footer';
 import { CustomLayout, Logo, DocsLink } from './styles';
@@ -13,6 +15,10 @@ import { CustomLayout, Logo, DocsLink } from './styles';
 const LogoSvg = dynamic(() => import('common-util/SVGs/logo'));
 
 const { Header, Content } = Layout;
+
+const StyledHeader = styled(Header)`
+  border-bottom: 1px solid ${COLOR.BORDER_GREY};
+`;
 
 const NavigationBar = ({ children }) => {
   const router = useRouter();
@@ -42,7 +48,7 @@ const NavigationBar = ({ children }) => {
 
   return (
     <CustomLayout pathname={router.pathname}>
-      <Header>
+      <StyledHeader>
         <div className="column-1">
           <Logo data-testid="tokenomics-logo">
             <LogoSvg />
@@ -57,7 +63,7 @@ const NavigationBar = ({ children }) => {
           onClick={handleMenuItemClick}
           items={[
             { key: 'donate', label: 'Donate' },
-            { key: 'dev-incentives', label: 'Developer Rewards' },
+            { key: 'dev-incentives', label: 'Dev Rewards' },
             { key: 'bonding-products', label: 'Bonding Products' },
             { key: 'my-bonds', label: 'My Bonds' },
             {
@@ -72,7 +78,7 @@ const NavigationBar = ({ children }) => {
           ]}
         />
         <Login />
-      </Header>
+      </StyledHeader>
 
       <Content className="site-layout">
         <div className="site-layout-background">


### PR DESCRIPTION
User story: As a bonder, I want to be able to easily see what products still have remaining supply.

Ticket: https://trello.com/c/jkOrAIz8/1337-as-a-bonder-i-want-to-be-able-to-easily-see-what-products-still-have-remaining-supply

Hide empty products – default on page load:
<img width="1312" alt="image" src="https://github.com/valory-xyz/autonolas-tokenomics-frontend/assets/66292936/a66ffa1a-5b50-4d31-8fdd-dd78d6cf1115">

Show empty products:
<img width="1312" alt="image" src="https://github.com/valory-xyz/autonolas-tokenomics-frontend/assets/66292936/75cd2461-750f-4f7b-94db-ce6b19cb1f0a">
