### PR TITLE
fix: add slash in pair URL in bonding page

### DIFF
--- a/components/Home/Bonding/requests.jsx
+++ b/components/Home/Bonding/requests.jsx
@@ -154,7 +154,7 @@ const getLpTokenNamesForProducts = async (productList, events) => {
 
     const getLpTokenLink = () => {
       if (lpTokenDetailsList[index].dex === DEX.UNISWAP) {
-        return `https://v2.info.uniswap.org/pair${component.token}`;
+        return `https://v2.info.uniswap.org/pair/${component.token}`;
       }
 
       if (lpTokenDetailsList[index].dex === DEX.BALANCER && lpChainId === 100) {


### PR DESCRIPTION
- One of the members on [Discord](https://discord.com/channels/899649805582737479/992476033125187594/1181162047426269264) pointed out that the URL for the pair is missing a slash.

<img width="954" alt="Screenshot" src="https://github.com/valory-xyz/autonolas-tokenomics-frontend/assets/22061815/22f920d8-35d8-4c58-b073-f3fc7a66aec6">
