### PR TITLE
Fix Bonding Products Loading

### DIFF
--- a/common-util/functions/functions.jsx
+++ b/common-util/functions/functions.jsx
@@ -117,3 +117,14 @@ export const getBlockTimestamp = async (block = 'latest') => {
 };
 
 export const isL1Network = (chainId) => chainId === 1 || chainId === 5 || chainId === LOCAL_FORK_ID;
+
+/**
+ * Creates a promise that resolves after a specified number of milliseconds.
+ * This can be used to introduce a delay in an asynchronous operation.
+ *
+ * @param {number} ms - The number of milliseconds to wait before resolving the promise.
+ * @returns {Promise<string>} A promise that resolves with the string 'done' after the delay.
+ */
+export const delay = (ms) => new Promise((resolve) => {
+  setTimeout(() => resolve('done'), ms);
+});

--- a/components/Home/Bonding/BondingList.jsx
+++ b/components/Home/Bonding/BondingList.jsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Button, Table, Tag, Tooltip, Typography,
+  Button, Spin, Table, Tag, Tooltip, Typography,
 } from 'antd';
 import { remove, round, isNaN } from 'lodash';
 import { COLOR, NA } from '@autonolas/frontend-library';
-import { QuestionCircleOutlined } from '@ant-design/icons';
+import { QuestionCircleOutlined, UnorderedListOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
 
 import { BONDING_PRODUCTS } from 'util/constants';
@@ -258,9 +258,27 @@ export const BondingList = ({ bondingProgramType, hideEmptyProducts }) => {
           account,
           depositoryAddress,
         )}
+        locale={{
+          emptyText: (
+            <div style={{ padding: '3rem' }}>
+              <UnorderedListOutlined style={{ fontSize: 64 }} className="mb-8" />
+              <br />
+              No products
+            </div>
+          ),
+        }}
         dataSource={getProductsDataSource()}
         bordered
-        loading={isLoading}
+        loading={{
+          spinning: isLoading,
+          tip: <Typography className="mt-8">
+            Loading products
+            <br />
+            This can take up to 30 seconds
+            {/* eslint-disable-next-line react/jsx-closing-tag-location */}
+          </Typography>,
+          indicator: <Spin active />,
+        }}
         pagination={false}
         scroll={{ x: 400 }}
       />

--- a/components/Home/Bonding/BondingList.jsx
+++ b/components/Home/Bonding/BondingList.jsx
@@ -190,7 +190,7 @@ export const BondingList = ({
   const { account, chainId } = useHelpers();
   const [isLoading, setIsLoading] = useState(false);
   const [errorState, setErrorState] = useState(false);
-  const [filteredProducts, setFilteredProducts] = useState([]); // (active / inactive products)
+  const [filteredProducts, setFilteredProducts] = useState([]);
   const [retry, setRetry] = useState(0);
 
   // if productDetails is `not null`, then open the deposit modal
@@ -293,18 +293,19 @@ export const BondingList = ({
         bordered
         loading={{
           spinning: isLoading,
-          tip: <Typography className="mt-8">
-            Loading products
-            {
-              retry > 0 && (
-              <>
-                <br />
-                This can take up to 30 seconds
-              </>
-              )
-            }
-            {/* eslint-disable-next-line react/jsx-closing-tag-location */}
-          </Typography>,
+          tip: (
+            <Typography className="mt-8">
+              Loading products
+              {
+                retry > 0 && (
+                <>
+                  <br />
+                  This can take up to 30 seconds
+                </>
+                )
+              }
+            </Typography>
+          ),
           indicator: <Spin active />,
         }}
         pagination={false}

--- a/components/Home/Bonding/BondingList.jsx
+++ b/components/Home/Bonding/BondingList.jsx
@@ -1,11 +1,13 @@
 import { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
-  Button, Spin, Table, Tag, Tooltip, Typography,
+  Button, Empty, Spin, Table, Tag, Tooltip, Typography,
 } from 'antd';
-import { remove, round, isNaN } from 'lodash';
+import {
+  round, isNaN, remove,
+} from 'lodash';
 import { COLOR, NA } from '@autonolas/frontend-library';
-import { QuestionCircleOutlined, UnorderedListOutlined } from '@ant-design/icons';
+import { ExclamationCircleTwoTone, QuestionCircleOutlined, UnorderedListOutlined } from '@ant-design/icons';
 import styled from 'styled-components';
 
 import { BONDING_PRODUCTS } from 'util/constants';
@@ -13,7 +15,7 @@ import { notifySpecificError, parseToEth } from 'common-util/functions';
 import { useHelpers } from 'common-util/hooks/useHelpers';
 import { ADDRESSES } from 'common-util/Contracts';
 import { Deposit } from './Deposit';
-import { getProductListRequest, getAllTheProductsNotRemoved } from './requests';
+import { getProductListRequest } from './requests';
 import { getLpTokenWithDiscount } from './requestsHelpers';
 
 const { Text } = Typography;
@@ -38,11 +40,12 @@ const getTitle = (title, tooltipDesc) => (
 );
 
 const getColumns = (
-  showNoSupply,
+  // showNoSupply,
   onClick,
   isActive,
   acc,
   depositoryAddress,
+  hideEmptyProducts,
 ) => {
   const columns = [
     { title: 'ID', dataIndex: 'id', key: 'id' },
@@ -159,7 +162,7 @@ const getColumns = (
         <Button
           type="primary"
           // disbled if there is no supply or if the user is not connected
-          disabled={showNoSupply || !acc}
+          disabled={!hideEmptyProducts || !acc}
           onClick={() => onClick(row)}
         >
           Bond
@@ -180,12 +183,15 @@ const getColumns = (
   return columns;
 };
 
-export const BondingList = ({ bondingProgramType, hideEmptyProducts }) => {
+export const BondingList = ({
+  bondingProgramType,
+  hideEmptyProducts,
+}) => {
   const { account, chainId } = useHelpers();
   const [isLoading, setIsLoading] = useState(false);
-  const [allProducts, setAllProducts] = useState([]); // all products
+  const [errorState, setErrorState] = useState(false);
   const [filteredProducts, setFilteredProducts] = useState([]); // (active / inactive products)
-  const showNoSupply = bondingProgramType === BONDING_PRODUCTS.ALL;
+  const [retry, setRetry] = useState(0);
 
   // if productDetails is `not null`, then open the deposit modal
   const [productDetails, setProductDetails] = useState(null);
@@ -195,21 +201,14 @@ export const BondingList = ({ bondingProgramType, hideEmptyProducts }) => {
 
   const getProducts = async () => {
     try {
+      setErrorState(false);
       setIsLoading(true);
 
-      // If bondingProgramType is allProduct, we will get all the products
-      // that are not removed
-      if (showNoSupply) {
-        // fetches "all" products
-        const productList = await getAllTheProductsNotRemoved();
-        setAllProducts(productList);
-      } else {
-        // fetches both "active" and "inactive" products
-        const filteredProductList = await getProductListRequest({ isActive });
-        setFilteredProducts(filteredProductList);
-      }
+      const filteredProductList = await getProductListRequest({ isActive }, retry);
+      setFilteredProducts(filteredProductList);
     } catch (error) {
       const errorMessage = typeof error?.message === 'string' ? error.message : null;
+      setErrorState(true);
       notifySpecificError('Error while fetching products', errorMessage);
       console.error(error, errorMessage);
     } finally {
@@ -220,7 +219,7 @@ export const BondingList = ({ bondingProgramType, hideEmptyProducts }) => {
   // fetch the bonding list
   useEffect(() => {
     getProducts();
-  }, [account, chainId, bondingProgramType]);
+  }, [account, chainId, bondingProgramType, retry]);
 
   const onBondClick = (row) => {
     setProductDetails(row);
@@ -237,24 +236,43 @@ export const BondingList = ({ bondingProgramType, hideEmptyProducts }) => {
   });
 
   const getProductsDataSource = () => {
-    const list = showNoSupply ? allProducts : filteredProducts;
-
-    const sortedList = sortList(list);
+    const sortedList = sortList(filteredProducts);
     const processedList = hideEmptyProducts
       ? sortedList.filter((x) => x.supplyLeft > 0.001) : sortedList;
 
     return processedList;
   };
 
+  const handleRetry = () => {
+    setRetry((prevRetry) => prevRetry + 1);
+  };
+
+  if (errorState) {
+    return (
+      <Container className="mt-16">
+        <Empty
+          description={(
+            <>
+              <Text className="mb-8">Couldn&apos;t fetch products</Text>
+              <br />
+              <Button onClick={handleRetry}>Try again</Button>
+            </>
+          )}
+          image={<ExclamationCircleTwoTone style={{ fontSize: '7rem' }} twoToneColor={COLOR.GREY_1} />}
+        />
+      </Container>
+    );
+  }
+
   return (
     <Container>
       <Table
         columns={getColumns(
-          showNoSupply,
           onBondClick,
           isActive,
           account,
           depositoryAddress,
+          hideEmptyProducts,
         )}
         locale={{
           emptyText: (
@@ -277,14 +295,21 @@ export const BondingList = ({ bondingProgramType, hideEmptyProducts }) => {
           spinning: isLoading,
           tip: <Typography className="mt-8">
             Loading products
-            <br />
-            This can take up to 30 seconds
+            {
+              retry > 0 && (
+              <>
+                <br />
+                This can take up to 30 seconds
+              </>
+              )
+            }
             {/* eslint-disable-next-line react/jsx-closing-tag-location */}
           </Typography>,
           indicator: <Spin active />,
         }}
         pagination={false}
         scroll={{ x: 400 }}
+        className="mb-16"
       />
 
       {!!productDetails && (

--- a/components/Home/Bonding/BondingList.jsx
+++ b/components/Home/Bonding/BondingList.jsx
@@ -258,10 +258,16 @@ export const BondingList = ({ bondingProgramType, hideEmptyProducts }) => {
         )}
         locale={{
           emptyText: (
-            <div style={{ padding: '3rem' }}>
-              <UnorderedListOutlined style={{ fontSize: 64 }} className="mb-8" />
-              <br />
-              No products
+            <div style={{ padding: '5rem' }}>
+              {isLoading ? ' '
+                : (
+                  <>
+                    <UnorderedListOutlined style={{ fontSize: 64 }} className="mb-8" />
+                    <br />
+                    No products
+
+                  </>
+                )}
             </div>
           ),
         }}

--- a/components/Home/Bonding/BondingList.jsx
+++ b/components/Home/Bonding/BondingList.jsx
@@ -238,7 +238,7 @@ export const BondingList = ({
   const getProductsDataSource = () => {
     const sortedList = sortList(filteredProducts);
     const processedList = hideEmptyProducts
-      ? sortedList.filter((x) => x.supplyLeft > 0.001) : sortedList;
+      ? sortedList.filter((x) => x.supplyLeft > 0.00001) : sortedList;
 
     return processedList;
   };

--- a/components/Home/Bonding/BondingList.jsx
+++ b/components/Home/Bonding/BondingList.jsx
@@ -130,7 +130,7 @@ const getColumns = (
       dataIndex: 'supply',
       key: 'supply',
       render: (x, row) => {
-        const supplyLeftInPercent = round(row.supplyLeft * 100, 0);
+        const supplyLeftInPercent = isNaN(row.supplyLeft) ? 0 : round(row.supplyLeft * 100, 0);
         return (
           <>
             <a
@@ -140,12 +140,10 @@ const getColumns = (
             >
               {round(parseToEth(x), 2)}
             </a>
-            &nbsp;
-            <Tooltip title={`${supplyLeftInPercent}% of supply left`}>
-              <Tag color={supplyLeftInPercent < 6 ? COLOR.RED : COLOR.PRIMARY}>
-                {`${supplyLeftInPercent}%`}
-              </Tag>
-            </Tooltip>
+            &nbsp;&nbsp;
+            <Tag color={supplyLeftInPercent < 6 ? COLOR.GREY_2 : COLOR.PRIMARY}>
+              {`${supplyLeftInPercent}%`}
+            </Tag>
           </>
         );
       },

--- a/components/Home/Bonding/requests.jsx
+++ b/components/Home/Bonding/requests.jsx
@@ -74,7 +74,7 @@ const getProductEventsFn = async (eventName) => {
   const lookbackBlocks = 100000;
   const chunkSize = 1000;
   const eventPromises = [];
-  const delayBetweenRequestsMs = 100;
+  const delayBetweenRequestsInMs = 100;
 
   for (
     let fromBlock = block.number - lookbackBlocks;
@@ -94,7 +94,7 @@ const getProductEventsFn = async (eventName) => {
   const eventsChunks = await Promise.all(
     eventPromises.map(
       (p, index) => p.then(
-        (result) => delay(index * delayBetweenRequestsMs).then(
+        (result) => delay(index * delayBetweenRequestsInMs).then(
           () => result.events,
         ),
       ),

--- a/components/Home/Bonding/requests.jsx
+++ b/components/Home/Bonding/requests.jsx
@@ -71,7 +71,7 @@ const getProductEventsFn = async (eventName) => {
   const provider = getEthersProvider();
   const block = await provider.getBlock('latest');
 
-  const oldestBlock = (getChainId() || 1) >= 100000 ? 50 : 1000000;
+  const oldestBlock = (getChainId() || 1) >= 100000 ? 50 : 100000;
   const events = contract.getPastEvents(eventName, {
     fromBlock: block.number - oldestBlock,
     toBlock: block.number,

--- a/components/Home/Bonding/requests.jsx
+++ b/components/Home/Bonding/requests.jsx
@@ -74,7 +74,7 @@ const getProductEventsFn = async (eventName, retry) => {
   // handle forked chains with very high chain IDs because they are
   // bad at handling large event lookbacks
   const lookbackBlockCount = (getChainId() || 1) >= 100000 ? 50 : 100000;
-  const chunkSize = retry > 0 ? 1000 : 50000;
+  const chunkSize = retry > 0 ? 500 : 50000;
   const eventPromises = [];
   const delayBetweenRequestsInMs = 100;
 

--- a/components/Home/Bonding/requests.jsx
+++ b/components/Home/Bonding/requests.jsx
@@ -71,13 +71,15 @@ const getProductEventsFn = async (eventName) => {
   const provider = getEthersProvider();
   const block = await provider.getBlock('latest');
 
-  const lookbackBlocks = 100000;
+  // handle forked chains with very high chain IDs because they are
+  // bad at handling large event lookbacks
+  const lookbackBlockCount = (getChainId() || 1) >= 100000 ? 50 : 1000000;
   const chunkSize = 1000;
   const eventPromises = [];
   const delayBetweenRequestsInMs = 100;
 
   for (
-    let fromBlock = block.number - lookbackBlocks;
+    let fromBlock = block.number - lookbackBlockCount;
     fromBlock <= block.number;
     fromBlock += chunkSize
   ) {

--- a/components/Home/BondingProducts.jsx
+++ b/components/Home/BondingProducts.jsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import styled from 'styled-components';
 import {
-  Typography, Radio, Switch, Divider,
+  Typography, Switch, Divider,
+  Radio,
+  Tooltip,
 } from 'antd';
 
 import { BONDING_PRODUCTS } from 'util/constants';
@@ -55,9 +57,10 @@ export const BondingProducts = () => {
         </Title>
         <ResponsiveDivider />
         <Radio.Group onChange={onChange} value={bondingProgramType}>
-          <Radio value={BONDING_PRODUCTS.ALL}>All</Radio>
           <Radio value={BONDING_PRODUCTS.ACTIVE}>Active</Radio>
-          <Radio value={BONDING_PRODUCTS.INACTIVE}>Inactive</Radio>
+          <Tooltip title="Currently displaying active products only. To view inactive products, call methods on the Depository contract via Etherscan.">
+            <Radio value={BONDING_PRODUCTS.INACTIVE} disabled>Inactive</Radio>
+          </Tooltip>
         </Radio.Group>
         <ResponsiveDivider />
         <SwitchContainer>


### PR DESCRIPTION
EDIT: I've updated this PR so that:
- by default, we use a large chunk size. Many/most people do not seem to experience the loading error, so it seems wasteful to massively slow down the loading for everyone by default
- instead, there's now an error state where people can "Try again" – this switches to using a much small block chunk size
- I've also removed the "All" tab, and associated code. Afaict, the purpose of this tab is now served by the "Hide empty products" toggle
- I also disabled the "Inactive" tab, which is currently not working, and put a tooltip instructing people to check the Depository contract on Etherscan. We can resolve this properly when it's priority.

<img width="949" alt="image" src="https://github.com/valory-xyz/autonolas-tokenomics-frontend/assets/66292936/4e7134e9-b9bb-47bc-8a7f-0421c01db683">


---

See ticket: https://trello.com/c/bbMGicyt/1372-%F0%9F%9A%A8-bonding-products-not-loading

This change aims to resolve an issue where users are being rate-limited. The issue appears to be because we are making large numbers of requests – particularly relating to event data – in very short periods. Users have also received error messages because they've been requesting more blocks at once than the RPC will tolerate.

The emphasis of this change is to chunk the event requests and spread them out slightly in time.

Note: the initial plan was to progressively hydrate the data. This was a complex change, and I ditched it halfway through in the interests of getting to done. The tradeoff is that all users will have slower loading times. To overcome this in the future, we can:
1. complete the initial hydration plan
2. add getter events to the contracts
3. consider a subgraph

Please test to see if you can reproduce the errors. I have not been able to.