### PR TITLE
feat: pop-confirm if difference is negative

### DIFF
--- a/components/Home/Bonding/BondingList.jsx
+++ b/components/Home/Bonding/BondingList.jsx
@@ -178,7 +178,8 @@ const getColumns = (
         if (isCurrentDifferenceNegative) {
           return (
             <Popconfirm
-              title="Current difference in value is negative – are you sure you want to bond?"
+              title="Current difference in value is negative"
+              description="Are you sure you want to bond?"
               okText="Proceed"
               cancelText="Cancel"
               placement="left"


### PR DESCRIPTION
- When the "current difference" is negative, a pop-up should appear to confirm the user's action.
- If the user clicks "proceed," the bond modal should open.

https://github.com/valory-xyz/autonolas-tokenomics-frontend/assets/22061815/3181a6bb-9ad5-4974-aa2e-10a5e6133875

