### PR TITLE
Coinbase wallet canonical fix

### DIFF
--- a/common-util/functions/frontend-library.js
+++ b/common-util/functions/frontend-library.js
@@ -4,17 +4,30 @@ import {
   getChainIdOrDefaultToMainnet as getChainIdOrDefaultToMainnetFn,
   sendTransaction as sendTransactionFn,
   LOCAL_FORK_ID,
+  notifyError,
 } from '@autonolas/frontend-library';
 
 import { RPC_URLS } from 'common-util/constants/rpcs';
 import { SUPPORTED_CHAINS } from 'common-util/config/wagmi';
+import { isString } from 'lodash';
 
 const supportedChains =
   process.env.NEXT_PUBLIC_IS_CONNECTED_TO_LOCAL === 'true'
     ? [...SUPPORTED_CHAINS, { id: LOCAL_FORK_ID }]
     : SUPPORTED_CHAINS;
 
-export const getProvider = () => getProviderFn(supportedChains, RPC_URLS);
+export const getProvider = () => {
+  const provider = getProviderFn(supportedChains, RPC_URLS);
+  // not connected, return mainnet URL
+  if (isString(provider)) return provider;
+  // coinbase injected multiwallet provider
+  if (provider?.selectedProvider) return provider.selectedProvider;
+  if (provider?.providerMap?.get('CoinbaseWallet'))
+    return provider?.providerMap?.get('CoinbaseWallet');
+  // standard provider
+  if (provider) return provider;
+  return notifyError('Provider not found');
+};
 
 export const getChainIdOrDefaultToMainnet = (chainId) =>
   getChainIdOrDefaultToMainnetFn(supportedChains, chainId);

--- a/common-util/functions/frontend-library.js
+++ b/common-util/functions/frontend-library.js
@@ -9,7 +9,6 @@ import {
 
 import { RPC_URLS } from 'common-util/constants/rpcs';
 import { SUPPORTED_CHAINS } from 'common-util/config/wagmi';
-import { isString } from 'lodash';
 
 const supportedChains =
   process.env.NEXT_PUBLIC_IS_CONNECTED_TO_LOCAL === 'true'
@@ -19,11 +18,11 @@ const supportedChains =
 export const getProvider = () => {
   const provider = getProviderFn(supportedChains, RPC_URLS);
   // not connected, return mainnet URL
-  if (isString(provider)) return provider;
+  if (typeof provider === 'string') return provider;
   // coinbase injected multiwallet provider
   if (provider?.selectedProvider) return provider.selectedProvider;
   if (provider?.providerMap?.get('CoinbaseWallet'))
-    return provider?.providerMap?.get('CoinbaseWallet');
+    return provider.providerMap.get('CoinbaseWallet');
   // standard provider
   if (provider) return provider;
   return notifyError('Provider not found');

--- a/common-util/functions/web3.js
+++ b/common-util/functions/web3.js
@@ -23,7 +23,7 @@ import {
  */
 const getWeb3Details = () => {
   const chainId = getChainId();
-  const web3 = new Web3(getProvider()); // TODO: refactor to use viem/wagmi with coinbaseWallet connector, this is root cause of coinbase wallet breaking
+  const web3 = new Web3(getProvider());
   return { web3, chainId };
 };
 


### PR DESCRIPTION
Coinbase injects a non-standard multi-wallet provider, with providers accessible through .ProviderMap
Added cases to getProvider to check and return the correct provider.

~May be better to roll out to @autonolas/frontend-library but unsure if this will be deprecated once we move to monorepo?~

Resolves the issue where both Coinbase and another non-aggressive provider that injects window.ethereum breaks the apps.