### PR TITLE
fix: Infinity should be fixed for Solana products.

### DIFF
--- a/components/Home/Bonding/BondingList/useBondingList.jsx
+++ b/components/Home/Bonding/BondingList/useBondingList.jsx
@@ -208,16 +208,10 @@ const useAddCurrentLpPriceToProducts = () => {
     getCurrentPriceBalancerFn,
   ]);
 
-  const getCurrentPriceForSvm = useCallback(async () => {
-    const priceLp = await getCurrentPriceWhirlpool(
-      ADDRESSES[VM_TYPE.SVM].balancerVault, // whirpool address
-    );
-    return priceLp;
-  }, [getCurrentPriceWhirlpool]);
-
   return useCallback(
     async (productList) => {
       const chainId = getChainId();
+      const svmPriceLp = await getCurrentPriceWhirlpool();
       const multicallRequests = {};
       const otherRequests = {};
 
@@ -251,11 +245,7 @@ const useAddCurrentLpPriceToProducts = () => {
               currentLpPrice = getCurrentPriceBalancer(productList[i].token);
               otherRequests[i] = currentLpPrice;
             } else if (dex === DEX.SOLANA) {
-              /* eslint-disable-next-line no-await-in-loop */
-              currentLpPrice = await getCurrentPriceForSvm(
-                productList[i].token,
-              );
-              otherRequests[i] = currentLpPrice;
+              otherRequests[i] = svmPriceLp;
             } else {
               throw new Error('Dex not supported');
             }
@@ -282,7 +272,7 @@ const useAddCurrentLpPriceToProducts = () => {
         currentPriceLp: resolvedList[index],
       }));
     },
-    [publicClient, getCurrentPriceBalancer, getCurrentPriceForSvm],
+    [publicClient, getCurrentPriceBalancer, getCurrentPriceWhirlpool],
   );
 };
 


### PR DESCRIPTION
### Problem: Upon initial load, the Solana products displayed incorrect values (0 and infinity), but worked correctly after a reload - happens intermittently

- The issue with displaying "Infinity" was due to division by 0. The LP price of the Solana product was 0 because we were using an async function but didn't wait until the promise was fulfilled.
- In the current fix, we don't need to call the LP price for each Solana product as it remains the same. Therefore, this will be called only once with appropriate async-await and shouldn't be an issue.
- Typescript could be a lifesaver here again

<img width="1483" alt="Screenshot" src="https://github.com/valory-xyz/autonolas-tokenomics-frontend/assets/22061815/6de652ac-a4f5-4e7d-a260-4d0cc58d1c67">
